### PR TITLE
去除评论中的 span标签内容

### DIFF
--- a/python 爬虫/douban/demo.py
+++ b/python 爬虫/douban/demo.py
@@ -30,7 +30,7 @@ def get_one(num):
 # 解析网页结构
 def parse_page(html):
     info = []
-    patten1 = re.compile(r'<div class="comment">.*?<a href=.*?class="">(.*?)</a>.*?<span class="comment-time " title="(.*?)">.*?</span>.*?<p class="">(.*?)</p>.*?</div>', re.S)
+    patten1 = re.compile(r'<div class="comment">.*?<a href=.*?class="">(.*?)</a>.*?<span class="comment-time " title="(.*?)">.*?</span>.*?<p class="">.*?<span class="short">(.*?)</span>.*?</p>.*?</div>', re.S)
     datas = re.findall(patten1, html)
     for data in datas:
         comic = {}


### PR DESCRIPTION
修改正则匹配样式，去除评论中的 '<span class="short">'